### PR TITLE
Support PARTITIONED/CLUSTERED BY in CREATE TABLE

### DIFF
--- a/lib/sequel/adapters/shared/spark.rb
+++ b/lib/sequel/adapters/shared/spark.rb
@@ -120,6 +120,10 @@ module Sequel
         _append_table_view_options_sql(super, options)
       end
 
+      def create_table_as_sql(name, sql, options)
+        _append_table_view_options_sql(create_table_prefix_sql(name, options), options) << " AS #{sql}"
+      end
+
       def create_view_sql(name, source, options)
         if source.is_a?(Hash)
           options = source

--- a/lib/sequel/adapters/shared/spark.rb
+++ b/lib/sequel/adapters/shared/spark.rb
@@ -142,6 +142,19 @@ module Sequel
           sql << " USING " << options[:using].to_s
         end
 
+        if options[:partitioned_by]
+          sql << " PARTITIONED BY " << _column_list(options[:partitioned_by])
+        end
+
+        if options[:clustered_by]
+          sql << " CLUSTERED BY " << _column_list(options[:clustered_by])
+          if options[:sorted_by]
+            sql << " SORTED BY " << _column_list(options[:sorted_by])
+          end
+          raise "Must specify :num_buckets when :clustered_by is used" unless options[:num_buckets]
+          sql << " INTO #{options[:num_buckets]} BUCKETS"
+        end
+
         if options[:options]
           sql << ' OPTIONS ('
           options[:options].each do |k, v|
@@ -151,6 +164,10 @@ module Sequel
         end
 
         sql
+      end
+
+      def _column_list(columns)
+        "(#{Array(columns).join(", ")})"
       end
 
       def drop_schema_sql(schema_name, opts)

--- a/sequel-hexspace.gemspec
+++ b/sequel-hexspace.gemspec
@@ -6,9 +6,9 @@ Gem::Specification.new do |s|
   s.rdoc_options += ["--quiet", "--line-numbers", "--inline-source", '--title', 'sequel-hexspace: Sequel adapter for hexspace driver and Apache Spark database', '--main', 'README']
   s.license = "MIT"
   s.summary = "Sequel adapter for hexspace driver and Apache Spark database"
-  #s.author = ""
-  #s.email = ""
-  #s.homepage = ""
+  s.author = "Jeremy Evans"
+  s.email = "code@jeremyevans.net"
+  s.homepage = "https://github.com/jeremyevans/sequel-hexspace.git"
   s.files = %w(LICENSE README) + Dir["lib/**/*.rb"]
   s.description = <<END
 This is a hexspace adapter for Sequel, designed to be used with Spark (not

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -168,6 +168,17 @@ describe "Database schema modifiers" do
     @db[:items].all.must_equal [{:x=>1}]
   end
 
+  it "should create tables with :partitioned_by, :clustered_by, :sorted_by and :num_buckets options" do
+    @db.create_table(:items, :using=>'parquet', :partitioned_by=>:x, :clustered_by=>[:y,:z], :num_buckets=>4, :sorted_by=>:z) do
+      Integer :x
+      Integer :y
+      Integer :z
+    end
+    @db[:items].delete # in case parquet file was already created
+    @db[:items].insert 1,2,3
+    @db[:items].all.must_equal [{:x=>1,:y=>2,:z=>3}]
+  end
+
   describe "views" do
     before do
       @db.drop_view(:items_view2) rescue nil

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -15,6 +15,15 @@ describe "Database" do
     @db.sqls.must_equal ["CREATE TABLE `parquetTable` (`x` integer) USING org.apache.spark.sql.parquet OPTIONS ('path'='/path/to/view.parquet')"]
   end
 
+  it "#create_table should support :partitioned_by, :clustered_by, :sorted_by and :num_buckets options" do
+    @db.create_table(:parquetTable, :using=>'parquet', :partitioned_by=>:x, :clustered_by=>[:y,:z], :num_buckets=>4, :sorted_by=>:z) do
+      Integer :x
+      Integer :y
+      Integer :z
+    end
+    @db.sqls.must_equal ["CREATE TABLE `parquetTable` (`x` integer, `y` integer, `z` integer) USING parquet PARTITIONED BY (x) CLUSTERED BY (y, z) SORTED BY (z) INTO 4 BUCKETS"]
+  end
+
   it "#create_view should support :using and :path options" do
     @db.create_view(:parquetTable, :temp=>true, :using=>'org.apache.spark.sql.parquet', :options=>{:path=>"/path/to/view.parquet"})
     @db.sqls.must_equal ["CREATE TEMPORARY VIEW `parquetTable` USING org.apache.spark.sql.parquet OPTIONS ('path'='/path/to/view.parquet')"]

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -24,6 +24,11 @@ describe "Database" do
     @db.sqls.must_equal ["CREATE TABLE `parquetTable` (`x` integer, `y` integer, `z` integer) USING parquet PARTITIONED BY (x) CLUSTERED BY (y, z) SORTED BY (z) INTO 4 BUCKETS"]
   end
 
+  it "#create_table should support :partitioned_by, :clustered_by, :sorted_by and :num_buckets options when :as is present" do
+    @db.create_table(:parquetTable, :using=>'parquet', :partitioned_by=>:x, :clustered_by=>[:y,:z], :num_buckets=>4, :sorted_by=>:z, as: @db["SELECT 1"])
+    @db.sqls.must_equal ["CREATE TABLE `parquetTable` USING parquet PARTITIONED BY (x) CLUSTERED BY (y, z) SORTED BY (z) INTO 4 BUCKETS AS SELECT 1"]
+  end
+
   it "#create_view should support :using and :path options" do
     @db.create_view(:parquetTable, :temp=>true, :using=>'org.apache.spark.sql.parquet', :options=>{:path=>"/path/to/view.parquet"})
     @db.sqls.must_equal ["CREATE TEMPORARY VIEW `parquetTable` USING org.apache.spark.sql.parquet OPTIONS ('path'='/path/to/view.parquet')"]


### PR DESCRIPTION
It turns out there are [several options supported by Spark's CREATE TABLE](https://spark.apache.org/docs/3.5.0/sql-ref-syntax-ddl-create-table-datasource.html) that I'd like to see supported.

I hacked in the necessary changes, but would appreciate it if you would review them and correct as needed.  For instance, these options aren't supported by CREATE VIEW, so I shouldn't have modified `_append_table_view_options_sql`.  Also, I throw an error if :clustered_by is used without :num_blocks being set, but it's inelegant and I'm sure you have a better kind of exception to raise in those cases. 